### PR TITLE
Add Portuguese documentation and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An application for digitizing ECG scans. (OSU Capstone Project 2020-21)
 
+[Leia em Português](README_PTBR.md)
+
 See [ecgdigitize](https://github.com/Tereshchenkolab/ecg-digitize) for the library implementing the grid and signal digitization.
 Cite published manuscript: J. D. Fortune, N. E. Coppa, K. T. Haq, H. Patel and L. G. Tereshchenko. Digitizing ECG image: a new method and open-source software code. 
 Computer Methods and Programs in Biomedicine 2022 Pages 106890. DOI: https://doi.org/10.1016/j.cmpb.2022.106890 https://www.sciencedirect.com/science/article/pii/S0169260722002723

--- a/README_PTBR.md
+++ b/README_PTBR.md
@@ -1,0 +1,61 @@
+# Paper ECG
+
+[Versão em inglês](README.md)
+
+## Autores
+- Natalie Coppa
+- Julian Fortune
+- Larisa Tereschenko (tereshch@ohsu.edu)
+
+Com ajuda de:
+- Kazi Haq
+- Hetal Patel
+
+## Visão Geral
+Aplicativo que digitaliza imagens de ECG em papel para gerar sinais digitais. Um exemplo de imagem de entrada:
+
+![fullscan](https://user-images.githubusercontent.com/25210657/120732384-13bb9400-c49a-11eb-9913-5e99da0f8d53.png)
+
+Produz sinais como:
+
+![fullscan-output](https://user-images.githubusercontent.com/25210657/120732452-3057cc00-c49a-11eb-8228-0d3f7cb31e78.png)
+
+Para uma descrição dos arquivos de código, consulte [ANALISE_CODIGOS_PTBR.md](docs/ANALISE_CODIGOS_PTBR.md).
+
+## Instalação
+Baixe a versão mais recente [aqui](https://github.com/Tereshchenkolab/paper-ecg/releases/latest).
+
+## Guia do Usuário
+O guia do usuário (em inglês) está disponível [neste link](USER-GUIDE.md).
+
+## Contribuindo
+Siga as instruções de configuração:
+- [macOS / Linux](SETUP.md)
+- [Windows](SETUP-WINDOWS.md)
+
+Após instalar as dependências e ativar o ambiente virtual, execute:
+```
+fbs run
+```
+No Windows pode ser necessário:
+```
+py -3.6 -m fbs run
+```
+
+### Build
+Para gerar um executável distribuível:
+```
+fbs build
+```
+No Windows pode ser necessário:
+```
+py -3.6 -m fbs build
+```
+
+## Dependências
+Requer Python 3.6.7 devido às limitações do `fbs`.
+
+## Citação
+Se utilizar este software, cite:
+Fortune JD, Coppa NE, Haq KT, Patel H, Tereshchenko LG. Digitizing ECG image: A new method and open-source software code. Computer Methods and Programs in Biomedicine, 2022. DOI: https://doi.org/10.1016/j.cmpb.2022.106890.
+

--- a/docs/ANALISE_CODIGOS_PTBR.md
+++ b/docs/ANALISE_CODIGOS_PTBR.md
@@ -1,0 +1,127 @@
+# Análise dos Códigos
+
+Este documento descreve o propósito de cada arquivo Python presente no repositório.
+
+## scripts/compare_ecg.py
+Compara dois sinais de ECG carregados de arquivos e plota cada par de canais para inspeção visual.
+
+## scripts/see_ecg.py
+Carrega um arquivo de ECG e exibe todos os canais disponíveis em gráficos separados.
+
+## scripts/signal_loader.py
+Lê arquivos de texto contendo valores de ECG, converte cada linha em números e retorna uma matriz com os canais.
+
+## scripts/utility.py
+Funções auxiliares para validação de números em formato de texto e para verificação de listas booleanas.
+
+## src/main/icons/updateIcon.py
+Gera automaticamente ícones em diversos tamanhos a partir de uma imagem base, incluindo um arquivo `.ico`.
+
+## src/main/python/Main.py
+Ponto de entrada da aplicação PyQt, inicializando o `ApplicationContext` e o controlador principal.
+
+## src/main/python/controllers/MainController.py
+Controla a janela principal: abertura e fechamento de imagens, processamento dos sinais e salvamento de anotações.
+
+## src/main/python/model/InputParameters.py
+Define os parâmetros de entrada usados na digitalização, como rotação, escalas e regiões de leads.
+
+## src/main/python/model/EcgModel.py
+Modelo simples que representa um ECG completo, armazenando leads e escalas padrão de grade.
+
+## src/main/python/model/Lead.py
+Enumeração e estrutura de dados para representar cada lead do ECG e sua posição na imagem.
+
+## src/main/python/Annotation.py
+Estruturas para salvar e carregar metadados de anotações feitas pelo usuário, incluindo cortes e escalas.
+
+## src/main/python/QtWrapper.py
+Conjunto de utilitários para facilitar a criação e o vínculo de widgets do Qt com classes Python.
+
+## src/main/python/ImageUtilities.py
+Funções de leitura de imagem e conversão entre formatos OpenCV e Qt.
+
+## src/main/python/Conversion.py
+Funções que recortam leads da imagem, digitizam sinais, estimam a grade e exportam os resultados em arquivo.
+
+## src/main/python/ecgdigitize/__init__.py
+Expõe funções principais do módulo `ecgdigitize`, como estimativa de rotação e digitalização de sinais e grade.
+
+## src/main/python/ecgdigitize/common.py
+Utilitários genéricos usados em todo o módulo, como operações matemáticas, filtros e manipulação de listas.
+
+## src/main/python/ecgdigitize/ecgdigitize.py
+Implementa o fluxo de digitalização: detecção e extração de sinais e da grade de fundo.
+
+## src/main/python/ecgdigitize/otsu.py
+Implementa o método de limiarização de Otsu e uma rotina de otimização simples.
+
+## src/main/python/ecgdigitize/image.py
+Abstrações para imagens coloridas, em tons de cinza e binárias, com operações de rotação, corte e conversão.
+
+## src/main/python/ecgdigitize/vision.py
+Funções de processamento de imagem baseadas em OpenCV, como Hough lines e filtros básicos.
+
+## src/main/python/ecgdigitize/visualization.py
+Rotinas para exibir imagens e sobrepor sinais ou linhas detectadas sobre imagens originais.
+
+## src/main/python/ecgdigitize/signal/__init__.py
+Reexporta funções relacionadas ao processamento de sinais de ECG.
+
+## src/main/python/ecgdigitize/signal/detection.py
+Converte uma imagem de lead em máscara binária do traçado, com métodos baseados em Otsu e heurísticas adaptativas.
+
+## src/main/python/ecgdigitize/signal/extraction/__init__.py
+Arquivo de inicialização vazio para o submódulo de extração de sinais.
+
+## src/main/python/ecgdigitize/signal/extraction/extraction.py
+Espaço reservado para estratégias de extração de sinais; atualmente contém apenas um cabeçalho.
+
+## src/main/python/ecgdigitize/signal/extraction/naive.py
+Extrai o sinal usando um método simples que encontra o centro das regiões ativas em cada coluna.
+
+## src/main/python/ecgdigitize/signal/extraction/viterbi.py
+Aplica uma versão do algoritmo de Viterbi para rastrear o caminho do traçado do sinal em uma imagem binária.
+
+## src/main/python/ecgdigitize/signal/signal.py
+Transforma imagens de leads em sinais numéricos e executa escalonamento e alinhamento temporal.
+
+## src/main/python/ecgdigitize/grid/__init__.py
+Arquivo de inicialização vazio para o submódulo de grade.
+
+## src/main/python/ecgdigitize/grid/frequency.py
+Estimativa da frequência da grade a partir de autocorrelação e interpolação de picos.
+
+## src/main/python/ecgdigitize/grid/detection.py
+Gera máscaras binárias da grade do papel usando limiarização e operações morfológicas.
+
+## src/main/python/ecgdigitize/grid/extraction.py
+Calcula o espaçamento da grade com base em análise de linhas e autocorrelação das densidades de pixels.
+
+## src/main/python/views/MessageDialog.py
+Janela de diálogo simples para exibir mensagens ao usuário com um botão OK.
+
+## src/main/python/views/ExportFileDialog.py
+Interface de exportação que permite escolher formato, delimitador e visualizar prévias dos leads digitalizados.
+
+## src/main/python/views/MainWindow.py
+Janela principal da aplicação, contendo menus, atalhos e integração com o editor de leads.
+
+## src/main/python/views/ImagePreviewDialog.py
+Exibe uma visualização de imagem recortada de um lead específico.
+
+## src/main/python/views/ROIView.py
+Implementa a área de seleção (ROI) com redimensionamento e movimentação para definir regiões de cada lead.
+
+## src/main/python/views/EditPanelGlobalView.py
+Painel com controles globais como rotação, escalas de tempo/voltagem e botões de processamento e salvamento.
+
+## src/main/python/views/EditPanelLeadView.py
+Painel para edição de um lead específico, permitindo ajustar o tempo inicial e excluir a ROI.
+
+## src/main/python/views/ImageView.py
+Componente de visualização de imagem com suporte a zoom, rotação, seleção de ROIs e atalhos.
+
+## src/main/python/views/EditorWidget.py
+Widget principal do editor que coordena a visualização da imagem, painéis de controle e gerenciamento das ROIs.
+

--- a/src/main/python/views/ExportFileDialog.py
+++ b/src/main/python/views/ExportFileDialog.py
@@ -121,7 +121,7 @@ class ExportFileDialog(QtWidgets.QDialog):
             caption="Export to File",
             filter="Text File (*.txt);;CSV (*.csv)"
         )
-        if path is not "" and selectedFilter in fileTypesDictionary:
+        if path != "" and selectedFilter in fileTypesDictionary:
             self.errorMessageLabel.setText("")
             self.chooseFileTextBox.setText(path)
             self.fileExportPath = path


### PR DESCRIPTION
## Summary
- Add README_PTBR.md com instruções básicas em Português
- Adicionar documentação de análise em Português para todos os arquivos Python
- Link README and Portuguese docs; fix citation and remove syntax warning in ExportFileDialog

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b5c13cffe8832f8706620551b55dae